### PR TITLE
Update syntax for Swift 3/iOS 10

### DIFF
--- a/Examples/iOS Example/AppDelegate.swift
+++ b/Examples/iOS Example/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Examples/tvOS Example/AppDelegate.swift
+++ b/Examples/tvOS Example/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Scripts/GenerateLicenseFile.swift
+++ b/Scripts/GenerateLicenseFile.swift
@@ -6,8 +6,8 @@ import Foundation
 
 extension String {
     func endsWith(str: String) -> Bool {
-        if let range = self.rangeOfString(str, options:NSStringCompareOptions.BackwardsSearch) {
-            return range.endIndex == self.endIndex
+        if let range = self.range(of: str, options:NSString.CompareOptions.backwardsSearch) {
+            return range.upperBound == self.endIndex
         }
         return false
     }
@@ -16,13 +16,13 @@ extension String {
 // MARK: Internal functions
 
 func locateLicenseInFolder(folder: String) -> String? {
-    let filemanager = NSFileManager.defaultManager()
+    let filemanager = FileManager.default()
     
-    guard let subpaths = try? filemanager.subpathsOfDirectoryAtPath(folder) else {
+    guard let subpaths = try? filemanager.subpathsOfDirectory(atPath: folder) else {
         return nil
     }
     
-    var filteredPaths = subpaths.filter { $0.endsWith("LICENSE") || $0.endsWith("LICENSE.txt") }
+    var filteredPaths = subpaths.filter { $0.endsWith(str: "LICENSE") || $0.endsWith(str: "LICENSE.txt") }
     filteredPaths = filteredPaths.map { folder + "/" + $0 }
     return filteredPaths.first
 }
@@ -33,7 +33,7 @@ func locateLicenseInFolder(folder: String) -> String? {
 let arguments = Process.arguments
 
 // Get the filename of the swift script for logging purposes
-let scriptFileName = arguments[0].componentsSeparatedByString("/").last!
+let scriptFileName = arguments[0].components(separatedBy: "/").last!
 
 // Check argument count
 if arguments.count != 3 {
@@ -45,15 +45,15 @@ var inDict = arguments[1]
 let outFile = arguments[2]
 
 // Add '/' to inDict if it is missing, otherwise the script will not find any subpaths
-if !inDict.endsWith("/") {
+if !inDict.endsWith(str: "/") {
     inDict += "/"
 }
 
 // Initialize default NSFileManager
-let filemanager = NSFileManager.defaultManager()
+let filemanager = FileManager.default()
 
 // Get subpaths (libraries at path)
-guard let libraries = try? filemanager.contentsOfDirectoryAtPath(inDict) where libraries.count > 0 else {
+guard let libraries = try? filemanager.contentsOfDirectory(atPath: inDict) where libraries.count > 0 else {
     print("Could not access directory at path \(inDict).")
     exit(1)
 }
@@ -64,8 +64,8 @@ var licenses = Array<Dictionary<String, String>>()
 // Load license for each library and add it to the result array
 libraries.forEach({ (library: String) in
     guard let
-        licensePath = locateLicenseInFolder(inDict + library),
-        licence = try? NSString(contentsOfFile: licensePath, encoding: NSUTF8StringEncoding) as String
+        licensePath = locateLicenseInFolder(folder: inDict + library),
+        licence = try? String(contentsOfFile: licensePath, encoding: String.Encoding.utf8)
         else {
             return
     }
@@ -74,7 +74,9 @@ libraries.forEach({ (library: String) in
 })
 
 // Generate plist from result array
-let plist = try! NSPropertyListSerialization.dataWithPropertyList(licenses, format: NSPropertyListFormat.XMLFormat_v1_0, options: 0)
+let plist = try! PropertyListSerialization.data(fromPropertyList: licenses, format: PropertyListSerialization.PropertyListFormat.xmlFormat_v1_0, options: 0)
 
 // Write plist to disk
-plist.writeToFile(outFile, atomically: true)
+if let url = URL(string: outFile) {
+    try plist.write(to: url, options: NSData.WritingOptions.atomicWrite)
+}

--- a/SwiftyAcknowledgements.xcodeproj/project.pbxproj
+++ b/SwiftyAcknowledgements.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Mathias Nagler";
 				TargetAttributes = {
 					5270467A1BE203CB004CD4FC = {
@@ -752,6 +752,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.SwiftyAcknowledgementsTests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -775,6 +776,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.SwiftyAcknowledgements-tvOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -812,6 +814,7 @@
 				PRODUCT_NAME = SwiftyAcknowledgements;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -820,9 +823,9 @@
 		52AAE6411BDF9A51007EB44A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Examples/tvOS Example/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.tvOS-Example";
@@ -836,14 +839,15 @@
 		52AAE6421BDF9A51007EB44A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Examples/tvOS Example/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.tvOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -886,7 +890,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -928,7 +932,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -948,11 +952,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "SwiftyAcknowledgements/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = de.mathiasnagler.SwiftyAcknowledgements;
 				PRODUCT_NAME = SwiftyAcknowledgements;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -966,36 +972,46 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "SwiftyAcknowledgements/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = de.mathiasnagler.SwiftyAcknowledgements;
 				PRODUCT_NAME = SwiftyAcknowledgements;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		52FC379D1B9F6BEF005EFE87 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "Examples/iOS Example/Supporting Files/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		52FC379E1B9F6BEF005EFE87 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "Examples/iOS Example/Supporting Files/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mathiasnagler.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS Tests.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS Tests.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/tvOS Example.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/tvOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyAcknowledgements/Acknowledgement.swift
+++ b/SwiftyAcknowledgements/Acknowledgement.swift
@@ -34,7 +34,7 @@ public struct Acknowledgement: Equatable {
     */
     public static func acknowledgementsFromPlistAtPath(path: String) -> [Acknowledgement] {
         var acknowledgements = [Acknowledgement]()
-        
+
         if let plist = NSArray(contentsOfFile: path) as? Array<Dictionary<String, String>> {
             for dict in plist {
                 if let
@@ -45,10 +45,9 @@ public struct Acknowledgement: Equatable {
                 }
             }
         }
-        
+
         return acknowledgements
     }
-    
 }
 
 // MARK: - Equatable

--- a/SwiftyAcknowledgements/AcknowledgementViewController.swift
+++ b/SwiftyAcknowledgements/AcknowledgementViewController.swift
@@ -13,9 +13,9 @@ public class AcknowledgementViewController: UIViewController {
     // MARK: Properties
     
     /// The font size used for displaying the acknowledgement's text
-    public var fontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(UIFontTextStyleBody) {
+    public var fontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(style: UIFontTextStyleBody) {
         didSet {
-            textView.font = UIFont.systemFontOfSize(fontSize)
+            textView.font = UIFont.systemFont(ofSize: fontSize)
         }
     }
     
@@ -24,21 +24,21 @@ public class AcknowledgementViewController: UIViewController {
     
     /// The textView used for displaying the acknowledgement's text
     public private(set) lazy var textView: UITextView = {
-        let textView = UITextView(frame: CGRectZero)
+        let textView = UITextView(frame: CGRect.zero)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.alwaysBounceVertical   = true
-        textView.font                   = UIFont.systemFontOfSize(self.fontSize)
+        textView.font                   = UIFont.systemFont(ofSize: self.fontSize)
         textView.textContainerInset     = UIEdgeInsetsMake(12, 10, 12, 10)
-        textView.userInteractionEnabled = true
+        textView.isUserInteractionEnabled = true
         
         #if os(iOS)
-            textView.editable           = false
-            textView.dataDetectorTypes  = .Link
+            textView.isEditable           = false
+            textView.dataDetectorTypes  = .link
         #endif
 
         #if os(tvOS)
-            textView.selectable = true
-            textView.panGestureRecognizer.allowedTouchTypes = [UITouchType.Indirect.rawValue]
+            textView.isSelectable = true
+            textView.panGestureRecognizer.allowedTouchTypes = [UITouchType.indirect.rawValue]
         #endif
         
         return textView
@@ -47,8 +47,8 @@ public class AcknowledgementViewController: UIViewController {
     #if os(tvOS)
         private var gradientLayer: CAGradientLayer = {
             let gradientLayer = CAGradientLayer()
-            gradientLayer.colors = [UIColor.clearColor().CGColor, UIColor.blackColor().CGColor,
-                UIColor.blackColor().CGColor, UIColor.clearColor().CGColor]
+            gradientLayer.colors = [UIColor.clear().cgColor, UIColor.black().cgColor,
+                UIColor.black().cgColor, UIColor.clear().cgColor]
             gradientLayer.locations = [0, 0.06, 1, 1]
             return gradientLayer
         }()
@@ -78,20 +78,20 @@ public class AcknowledgementViewController: UIViewController {
         view.addSubview(textView)
         
         #if os(tvOS)
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Top, relatedBy: .Equal, toItem: topLayoutGuide, attribute: .Bottom, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Bottom, relatedBy: .Equal, toItem: view, attribute: .Bottom, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .CenterX, relatedBy: .Equal, toItem: view, attribute: .CenterX, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Width, relatedBy: .Equal, toItem: view, attribute: .Width, multiplier: 0.7, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .top, relatedBy: .equal, toItem: topLayoutGuide, attribute: .bottom, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .centerX, relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 0.7, constant: 0))
         #else
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Top, relatedBy: .Equal, toItem: view, attribute: .Top, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Leading, relatedBy: .Equal, toItem: view, attribute: .Leading, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Bottom, relatedBy: .Equal, toItem: view, attribute: .Bottom, multiplier: 1, constant: 0))
-            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .Trailing, relatedBy: .Equal, toItem: view, attribute: .Trailing, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .leading, relatedBy: .equal, toItem: view, attribute: .leading, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1, constant: 0))
+            view.addConstraint(NSLayoutConstraint(item: textView, attribute: .trailing, relatedBy: .equal, toItem: view, attribute: .trailing, multiplier: 1, constant: 0))
         #endif
             
         textView.text = acknowledgement.text
         title = acknowledgement.title
-        textView.contentOffset = CGPointZero
+        textView.contentOffset = CGPoint.zero
         
         #if os(tvOS)
             textView.superview?.layer.mask = gradientLayer

--- a/SwiftyAcknowledgements/AcknowledgementsTableViewController.swift
+++ b/SwiftyAcknowledgements/AcknowledgementsTableViewController.swift
@@ -29,34 +29,34 @@ public class AcknowledgementsTableViewController: UITableViewController {
     }
     
     /// The font size to be used for the **UITableView**'s **tableHeader**. Defaults to the size of **UIFontTextStyleSubheadline**
-    @IBInspectable public var headerFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(UIFontTextStyleSubheadline) {
+    @IBInspectable public var headerFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(style: UIFontTextStyleSubheadline) {
         didSet {
             tableView.tableHeaderView = newTableHeaderView
         }
     }
     
     /// The font size to be used for the **UITableView**'s **tableFooter**. Defaults to the size of **UIFontTextStyleSubheadline**
-    @IBInspectable public var footerFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(UIFontTextStyleSubheadline) {
+    @IBInspectable public var footerFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(style: UIFontTextStyleSubheadline) {
         didSet {
             tableView.tableFooterView = newTableHeaderView
         }
     }
     
     /// The font size to be used for the **UITableView**'s cells. Defaults to the size of **UIFontTextStyleBody**
-    @IBInspectable public var detailFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(UIFontTextStyleBody)
+    @IBInspectable public var detailFontSize: CGFloat = UIFontDescriptor.preferredFontSizeWithTextStyle(style: UIFontTextStyleBody)
 
     /// The name of the plist containing the acknowledgements, defaults to **Acknowledgements**.
     @IBInspectable public var acknowledgementsPlistName = "Acknowledgements"
     
     private lazy var _acknowledgements: [Acknowledgement] = {
         guard let
-            acknowledgementsPlistPath = NSBundle.mainBundle().pathForResource(
+            acknowledgementsPlistPath = Bundle.main().pathForResource(
                 self.acknowledgementsPlistName, ofType: "plist")
         else {
             return [Acknowledgement]()
         }
 
-        return Acknowledgement.acknowledgementsFromPlistAtPath(acknowledgementsPlistPath)
+        return Acknowledgement.acknowledgementsFromPlistAtPath(path: acknowledgementsPlistPath)
     }()
     
     /// The acknowledgements that are displayed by the TableViewController. The array is initialized with the contents of the
@@ -64,7 +64,7 @@ public class AcknowledgementsTableViewController: UITableViewController {
     /// reload its contents after any modification to the array.
     public var acknowledgements: [Acknowledgement] {
         set {
-            _acknowledgements = sortingClosure != nil ? newValue.sort(sortingClosure!) : newValue
+            _acknowledgements = sortingClosure != nil ? newValue.sorted(isOrderedBefore: sortingClosure!) : newValue
             tableView.reloadData()
         }
         get {
@@ -84,11 +84,11 @@ public class AcknowledgementsTableViewController: UITableViewController {
     /// will reload its contents.
     public var sortingClosure: SortingClosure? = { (left, right) in
         var comparsion = left.title.compare(right.title)
-        return comparsion == .OrderedAscending
+        return comparsion == .orderedAscending
     } {
         didSet {
             if let sortingClosure = sortingClosure {
-                _acknowledgements = _acknowledgements.sort(sortingClosure)
+                _acknowledgements = _acknowledgements.sorted(isOrderedBefore: sortingClosure)
             }
         }
     }
@@ -96,59 +96,59 @@ public class AcknowledgementsTableViewController: UITableViewController {
     // MARK: Initialization
     
     public init(acknowledgementsPlistPath: String? = nil) {
-        super.init(style: .Grouped)
+        super.init(style: .grouped)
     }
     
-    override internal init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override internal init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
     required public init?(coder aDecoder: NSCoder) {
-        super.init(style: .Grouped)
+        super.init(style: .grouped)
     }
     
     // MARK: UIViewController overrides
     
     public override func viewDidLoad() {
-        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseId)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.reuseId)
         
         super.viewDidLoad()
     }
     
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         if title == nil {
             title = "Acknowledgements"
         }
         
         super.viewWillAppear(animated)
     }
-    
-    public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         
         tableView.tableHeaderView = tableView.tableHeaderView
         tableView.tableFooterView = tableView.tableFooterView
     }
-    
+
     // MARK: UITableViewDataSource
-    
-    public override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier(UITableViewCell.reuseId, forIndexPath: indexPath)
+
+    public override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseId, for: indexPath)
         cell.textLabel?.text = acknowledgements[indexPath.row].title
-        cell.accessoryType = .DisclosureIndicator
+        cell.accessoryType = .disclosureIndicator
         return cell
     }
-    
-    public override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+
+    public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return acknowledgements.count
     }
-    
+
     // MARK: UITableViewDelegate
-    
-    public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+
+    public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let detailViewController = AcknowledgementViewController(acknowledgement: acknowledgements[indexPath.row])
         detailViewController.fontSize = detailFontSize
-        showViewController(detailViewController, sender: self)
+        show(detailViewController, sender: self)
     }
     
     // MARK: TableView Header and Footer
@@ -179,7 +179,7 @@ public class AcknowledgementsTableViewController: UITableViewController {
 
 private extension UITableViewCell {
     static var reuseId: String {
-        return String(self).componentsSeparatedByString(".").last!
+        return String(self).components(separatedBy: ".").last!
     }
 }
 
@@ -194,17 +194,17 @@ private class HeaderFooterView: UIView {
             return label.font.pointSize
         }
         set {
-            label.font = UIFont.systemFontOfSize(newValue)
+            label.font = UIFont.systemFont(ofSize: newValue)
         }
     }
     
     lazy var label: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .Center
+        label.textAlignment = .center
         label.numberOfLines = 0
-        label.textColor = .grayColor()
-        label.font = UIFont.systemFontOfSize(12)
+        label.textColor = .gray()
+        label.font = UIFont.systemFont(ofSize: 12)
         return label
     }()
     
@@ -222,10 +222,10 @@ private class HeaderFooterView: UIView {
     
     private func commonInit() {
         addSubview(label)
-        self.addConstraint(NSLayoutConstraint(item: self, attribute: .Leading, relatedBy: .Equal, toItem: label, attribute: .Leading, multiplier: 1, constant: -16))
-        self.addConstraint(NSLayoutConstraint(item: self, attribute: .Trailing, relatedBy: .Equal, toItem: label, attribute: .Trailing, multiplier: 1, constant: 16))
-        self.addConstraint(NSLayoutConstraint(item: self, attribute: .Top, relatedBy: .Equal, toItem: label, attribute: .Top, multiplier: 1, constant: -16))
-        self.addConstraint(NSLayoutConstraint(item: self, attribute: .Bottom, relatedBy: .Equal, toItem: label, attribute: .Bottom, multiplier: 1, constant: 16))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal, toItem: label, attribute: .leading, multiplier: 1, constant: -16))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal, toItem: label, attribute: .trailing, multiplier: 1, constant: 16))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal, toItem: label, attribute: .top, multiplier: 1, constant: -16))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal, toItem: label, attribute: .bottom, multiplier: 1, constant: 16))
     }
     
     // MARK: UIView overrides
@@ -239,14 +239,13 @@ private class HeaderFooterView: UIView {
     
     private func resize() {
         translatesAutoresizingMaskIntoConstraints = false
-        let widthConstraint = NSLayoutConstraint(item: self, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: superview?.bounds.width ?? 500)
-        widthConstraint.active = true
-        let height = systemLayoutSizeFittingSize(UILayoutFittingCompressedSize).height
+        let widthConstraint = NSLayoutConstraint(item: self, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: superview?.bounds.width ?? 500)
+        widthConstraint.isActive = true
+        let height = systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
         removeConstraint(widthConstraint)
         
         translatesAutoresizingMaskIntoConstraints = true
-        
-        self.bounds = CGRectMake(0, 0, self.bounds.width, height)
+
+        self.bounds = CGRect(x: 0, y: 0, width: self.bounds.width, height: height)
     }
-    
 }

--- a/SwiftyAcknowledgements/UIFontDescriptorExtensions.swift
+++ b/SwiftyAcknowledgements/UIFontDescriptorExtensions.swift
@@ -13,7 +13,7 @@ internal extension UIFontDescriptor {
     /// Returns the point-size of the preffered font for a text style
     /// The user can influence this value by changing the font-size setting
     internal class func preferredFontSizeWithTextStyle(style: String) -> CGFloat {
-        let style = self.preferredFontDescriptorWithTextStyle(style)
+        let style = self.preferredFontDescriptor(withTextStyle: style)
         return style.pointSize
     }
 

--- a/Tests/AcknowledgementTests.swift
+++ b/Tests/AcknowledgementTests.swift
@@ -18,10 +18,10 @@ class AcknowledgementsTests: BaseTestCase {
         XCTAssertEqual(acknowledgement.title, title, "The acknowledgements title was incorrect.")
         XCTAssertEqual(acknowledgement.text, text, "The acknowledgements text was incorrect.")
     }
-    
+
     func testLoadAcknowledgementsFromPlist() {
-        let plist = StringForResource("Acknowledgements", ofType: "plist")
-        let acknowledgements = Acknowledgement.acknowledgementsFromPlistAtPath(plist)
+        let plist = StringForResource(fileName: "Acknowledgements", ofType: "plist")
+        let acknowledgements = Acknowledgement.acknowledgementsFromPlistAtPath(path: plist)
         XCTAssert(acknowledgements.count > 0, "No acknowledgements loaded. Is the plist empty?")
     }
     

--- a/Tests/AcknowledgementsTableViewControllerTests.swift
+++ b/Tests/AcknowledgementsTableViewControllerTests.swift
@@ -46,7 +46,7 @@ class AcknowledgementsTableViewControllerTests: BaseTestCase {
     func testCustomStorting() {
         viewController.sortingClosure = { (left: Acknowledgement, right: Acknowledgement) in
             let comparsion = left.title.compare(right.title)
-            return comparsion == .OrderedDescending
+            return comparsion == .orderedDescending
         }
             
         XCTAssert(viewController.acknowledgements == [d, c, b, a], "Custom sort did not produce an alphabetically descending sorted list.")
@@ -58,7 +58,7 @@ class AcknowledgementsTableViewControllerTests: BaseTestCase {
     }
     
     func testTableDataSourceCellForRowAtIndexPath() {
-        let cell = viewController.tableView(viewController.tableView, cellForRowAtIndexPath: NSIndexPath(forItem: 0, inSection: 0))
+        let cell = viewController.tableView(viewController.tableView, cellForRowAt: IndexPath(item: 0, section: 0))
         XCTAssertEqual(cell.textLabel!.text, viewController.acknowledgements[0].title)
     }
     

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -13,12 +13,12 @@ import SwiftyAcknowledgements
 class BaseTestCase: XCTestCase {
     
     func URLForResource(fileName: String, withExtension: String) -> NSURL {
-        let bundle = NSBundle(forClass: BaseTestCase.self)
-        return bundle.URLForResource(fileName, withExtension: withExtension)!
+        let bundle = Bundle(for: BaseTestCase.self)
+        return bundle.urlForResource(fileName, withExtension: withExtension)!
     }
     
     func StringForResource(fileName: String, ofType: String) -> String {
-        let bundle = NSBundle(forClass: BaseTestCase.self)
+        let bundle = Bundle(for: BaseTestCase.self)
         return bundle.pathForResource(fileName, ofType: ofType)!
     }
     


### PR DESCRIPTION
Re: issue #1, this pull request provides preliminary support for Swift 3 and iOS 10.  I've update syntax wherever there were warning and errors on build, and I've tested as far as the iOS example application, which seems to work.  tvOS simulator seems to be a bit wonky in Beta 1, so was unable to test there.

Unit tests will not run currently as there is a complaint on compile about an invalid path.  I haven't looked at this yet, but expect the library should hopefully work.
