### PR TITLE
Disable codeCoverageEnabled

### DIFF
--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements iOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS.xcscheme
+++ b/SwiftyAcknowledgements.xcodeproj/xcshareddata/xcschemes/SwiftyAcknowledgements tvOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
When building with Xcode 9 against the iOS 11 SDK, Apple has a new
automatic check after uploading the binary:

> Invalid Bundle - Disallowed LLVM instrumentation. Do not submit
> apps with LLVM profiling instrumentation or coverage collection
> enabled. Turn off LLVM profiling or code coverage, rebuild your
> app and resubmit the app.

This library is affected by this problem when using Carthage to
integrate it.