### PR TITLE
[Bug] Fix plist will not be sorted

### DIFF
--- a/SwiftyAcknowledgements/AcknowledgementsTableViewController.swift
+++ b/SwiftyAcknowledgements/AcknowledgementsTableViewController.swift
@@ -60,7 +60,8 @@ public class AcknowledgementsTableViewController: UITableViewController {
             return [Acknowledgement]()
         }
 
-        return Acknowledgement.acknowledgements(fromPlistAt: acknowledgementsPlistPath)
+        let acknowledgements = Acknowledgement.acknowledgements(fromPlistAt: acknowledgementsPlistPath)
+        return self.sortingClosure != nil ? acknowledgements.sorted(by: self.sortingClosure!) : acknowledgements
     }()
     
     /// The acknowledgements that are displayed by the TableViewController. The array is initialized with the contents of the


### PR DESCRIPTION
If acknowledgements are read from plist, the library names will not be sorted. Fixed.